### PR TITLE
Sorting Issue in RangeReadKV Output

### DIFF
--- a/go/pkg/pumicecommon/pumicecommon.go
+++ b/go/pkg/pumicecommon/pumicecommon.go
@@ -51,6 +51,12 @@ type GossipInfo struct {
 	Ports  []uint16 `yaml:"ports"`
 }
 
+// Data represents a key-value pair
+type Data struct {
+	Key   string
+	Value []byte
+}
+
 const (
 	APP_REQ     int = 0
 	LEASE_REQ       = 1

--- a/go/pkg/utils/ctlmonitor/requestResponseLib.go
+++ b/go/pkg/utils/ctlmonitor/requestResponseLib.go
@@ -1,10 +1,14 @@
 package lookout
 
+import (
+	"github.com/00pauln00/niova-pumicedb/go/pkg/pumicecommon"
+)
+
 type KVRequest struct {
-	Operation  string
-	Key        string
-	Value      []byte
-	CheckSum   [16]byte
+	Operation string
+	Key       string
+	Value     []byte
+	CheckSum  [16]byte
 }
 
 type KVResponse struct {
@@ -15,14 +19,14 @@ type KVResponse struct {
 type PMDBKVResponse struct {
 	Status       int
 	Key          string
-	ResultMap    map[string][]byte
+	Result       []pumicecommon.Data // Changed from map to slice to preserve RocksDB ordering
 	ContinueRead bool
 	Prefix       string
-	SeqNum	     uint64
+	SeqNum       uint64
 	SnapMiss     bool
 }
 
 type LookoutRequest struct {
-	UUID	[16]byte
-	Cmd	string
+	UUID [16]byte
+	Cmd  string
 }


### PR DESCRIPTION
Related to: https://github.com/00pauln00/niova-pumicedb/issues/55

Currently data from ReadAllKV method returns map[string]string which does not keep order of the data send back by RocksDB. changing it to slice to maintain order.