### PR TITLE
Fix: Propagate server-side errors to client instead of silent failures

### DIFF
--- a/go/pkg/pumicefunc/common/funclib.go
+++ b/go/pkg/pumicefunc/common/funclib.go
@@ -29,3 +29,9 @@ type FuncIntrm struct {
 	Changes  []CommitChg
 	Response []byte
 }
+
+// FuncError is encoded into HTTP 200 response bodies when a registered function
+// errors; non-empty Msg identifies the error and carries the message.
+type FuncError struct {
+	Msg string
+}

--- a/go/pkg/pumicefunc/server/funcserver.go
+++ b/go/pkg/pumicefunc/server/funcserver.go
@@ -78,6 +78,23 @@ func copyResultToBuffer(r interface{}, buf unsafe.Pointer, bufsz int) int64 {
 	return size
 }
 
+// encodeFuncError writes a FuncError marker into the PMDB output buffer so
+// the real error message survives the PMDB layer instead of being lost as -1.
+func encodeFuncError(err error, buf unsafe.Pointer, bufsz int) int64 {
+	fe := funclib.FuncError{Msg: err.Error()}
+	var enc bytes.Buffer
+	if encErr := gob.NewEncoder(&enc).Encode(fe); encErr != nil {
+		log.Errorf("encodeFuncError: failed to encode FuncError: %v", encErr)
+		return -1
+	}
+	size, copyErr := pmsvr.PmdbCopyBytesToBuffer(enc.Bytes(), buf)
+	if copyErr != nil {
+		log.Errorf("encodeFuncError: failed to copy FuncError to buffer: %v", copyErr)
+		return -1
+	}
+	return size
+}
+
 func (fs *FuncServer) WritePrep(wpa *pmsvr.PmdbCbArgs) int64 {
 	r, err := decode(wpa.Payload)
 	if err != nil {
@@ -89,7 +106,9 @@ func (fs *FuncServer) WritePrep(wpa *pmsvr.PmdbCbArgs) int64 {
 		res, err := fn(r.Args, wpa)
 		if err != nil {
 			log.Errorf("Write prep function %s failed: %v", r.Name, err)
-			return -1
+			// Encode error as FuncError marker; omit DiscontinueWrite so Apply
+			// can route the real error to ReplyBuf without committing any changes.
+			return encodeFuncError(err, wpa.AppData, int(wpa.AppDataSize))
 		}
 		size := copyResultToBuffer(res, wpa.AppData, int(wpa.AppDataSize))
 		//Continue write if the function executed successfully
@@ -122,8 +141,8 @@ func (fs *FuncServer) Apply(apar *pmsvr.PmdbCbArgs) int64 {
 	if fn, exists := fs.ApplyFuncs[r.Name]; exists {
 		res, err = fn(r.Args, apar)
 		if err != nil {
-			log.Error("Apply function %s failed: %v", r.Name, err)
-			return -1
+			log.Errorf("Apply function %s failed: %v", r.Name, err)
+			return encodeFuncError(err, apar.ReplyBuf, int(apar.ReplySize))
 		}
 		goto out
 
@@ -136,8 +155,8 @@ func (fs *FuncServer) Apply(apar *pmsvr.PmdbCbArgs) int64 {
 		}
 		res, err = fn(apar)
 		if err != nil {
-			log.Error("Default apply function failed: %v", err)
-			return -1
+			log.Errorf("Default (wildcard) apply function failed: %v", err)
+			return encodeFuncError(err, apar.ReplyBuf, int(apar.ReplySize))
 		}
 	}
 
@@ -157,7 +176,7 @@ func (fs *FuncServer) Read(rda *pmsvr.PmdbCbArgs) int64 {
 		res, err := fn(rda, r.Args)
 		if err != nil {
 			log.Errorf("Read function %s failed: %v", r.Name, err)
-			return -1
+			return encodeFuncError(err, rda.ReplyBuf, int(rda.ReplySize))
 		}
 		size := copyResultToBuffer(res, rda.ReplyBuf, int(rda.ReplySize))
 		return size

--- a/go/pkg/utils/httpclient/httpclient.go
+++ b/go/pkg/utils/httpclient/httpclient.go
@@ -28,8 +28,12 @@ func service_Request(request *http.Request) ([]byte, error) {
 	case 503:
 		//Service not found, returned for timeout
 		return nil, errors.New("Server timed out")
+	default:
+		// Non-200, non-503 responses discard the body silently (nil, nil).
+		// Proxy must use HTTP 200 + FuncError body to propagate errors.
+		log.Warnf("httpclient: received HTTP %d for %s %s — response body discarded", response.StatusCode, request.Method, request.URL)
+		return nil, nil
 	}
-	return nil, nil
 }
 
 func HTTP_Request(requestBody []byte, address string, put bool) ([]byte, error) {


### PR DESCRIPTION
encode errors as FuncError instead of returning -1, Previously, when WritePrep, Apply, or Read functions returned an error, funcserver wrote -1 to the PMDB buffer. This caused the error message to be lost — clients received an EOF or nil response with no indication of what failed.